### PR TITLE
Use new M1 MacOS runner available to open source

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11']
-    runs-on: macos-13-xlarge
+    runs-on: macos-14
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4


### PR DESCRIPTION
See https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/