### PR TITLE
Migrate actions to Node 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Prepare build environment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,9 +38,9 @@ jobs:
           python setup.py build -j 6
           python setup.py bdist_wheel
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.python-version }}
           path: zeroc-ice-3.6.5/dist/*.whl
           if-no-files-found: error
   release:
@@ -49,11 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts from build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: List artifacts
         run: ls -R
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            artifacts/*.whl
+            artifacts-*/*.whl


### PR DESCRIPTION
See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Probably the biggest breaking change affects this as well as other repositories is that the artifacts created by the GitHub actions are now `immutable` - see https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact.

For matrix builds, we are now creating multiple artifacts suffixed with the Python version using `actions/upload-artifact@v4`. In the release step, these artifacts are downloaded using `actions/download-artifact@v4` and aggregated into release assets - see https://github.com/sbesson/zeroc-ice-py-macos-universal2/actions/runs/7782477418 and https://github.com/sbesson/zeroc-ice-py-macos-universal2/releases/tag/20240205 for a proof-of-concept when a tag is pushed

